### PR TITLE
Test travis on php 5.5 and 5.6 and 5.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: php
 php:
+  - "7"
+  - "5.6"
+  - "5.5"
   - "5.4"
   - "5.3"
 install:


### PR DESCRIPTION
Reason since integration.wikimedia.org might be on a newer host that uses a newer php soon. Might as well test to make sure everything works.