### PR TITLE
disk: set threshold of maximumBelow 1TB to not include NFS

### DIFF
--- a/inc/Nagf.php
+++ b/inc/Nagf.php
@@ -85,12 +85,11 @@ class Nagf {
 			'disk' => array(
 				'title' => 'Disk space',
 				'targets' => array(
-					'aliasByNode(maximumAbove(HOST.diskspace.*.byte_avail,0),-3,-2)',
+					'aliasByNode(maximumBelow(maximumAbove(HOST.diskspace.*.byte_avail,0),1099511627776),-3,-2)',
 				),
 				'overview' => array(
-					'alias(stacked(sum(HOST.diskspace.*.byte_avail)),"byte_avail")',
+					'alias(sum(maximumBelow(maximumAbove(HOST.diskspace.*.byte_avail,0),1099511627776)),"byte_avail")',
 				),
-				'overview' => 'sum',
 			),
 			'network-bytes' => array(
 				'title' => 'Network bytes',


### PR DESCRIPTION
With diamond upgraded (T97635), it started collecting NFS data and
make instance-local storage essentially invisible (T171583). As far  
as I am aware no NFS mounts have disk space below 1TB and no        
instance-local storage has disk space above 1TB.