### PR TITLE
Add graphs for 1-minute load average like Ganglia

### DIFF
--- a/inc/Nagf.php
+++ b/inc/Nagf.php
@@ -45,6 +45,20 @@ class Nagf {
 
 	protected function getHostGraphsConfig() {
 		return array(
+			'load' => array(
+				'title' => 'Load',
+				'targets' => array(
+					'alias(color(stacked(HOST.loadavg.01),"#bbbbbb"),"1-min")',
+					'alias(color(HOST.cpu.cpu_count,"red"),"CPUs")',
+					'alias(color(HOST.loadavg.processes_running,"#2030f4"),"Procs")',
+				),
+				'overview' => array(
+					'alias(color(stacked(sum(HOST.loadavg.01)),"#bbbbbb"),"1-min")',
+					'alias(color(sum(HOST.cpu.cpu_count),"red"),"CPUs")',
+					'alias(color(sum(offset(scale(HOST.loadavg.01,0),1)),"green"),"Nodes")',
+					'alias(color(sum(HOST.loadavg.processes_running),"#2030f4"),"Procs")',
+				),
+			),
 			'cpu' => array(
 				'title' => 'CPU',
 				'targets' => array(


### PR DESCRIPTION
With diamond upgraded (T97635), HOST.cpu.cpu_count is added. The
number of nodes should be calculated by isNonNull() but that is not
available in our version of Graphite. We workaround that by scaling   
the loads to 0, offset them with 1, and finally calculating a sum;    
only non-null values will be scaled and offset-ed, contributing to
the sum.

For some reason the running process counts look larger than that
would have been reported by Ganglia.

Fixes #8